### PR TITLE
Added a way to add external and internal watchlist to incidents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,39 @@ serviceDesk.showIncident(100, function (res) {
 });
 ```
 
+###Create a internal watchlist for an incident
+```javascript
+var ServiceDesk = require('gta-service-desk');
+
+serviceDesk = new ServiceDesk('API_KEY');
+
+var watch = {
+    watched_by: GTA_USER_ID
+}
+
+serviceDesk.createIncidentWatch(100, watch, function (res) {
+    console.log( "Successfully created watch #" + res.watch.id )
+});
+```
+
+###Create an external watchlist for an incident
+```javascript
+var ServiceDesk = require('gta-service-desk');
+
+serviceDesk = new ServiceDesk('API_KEY');
+
+var watch = {
+    watched_by: INCREMENT,
+    external_email: EMAIL
+}
+
+serviceDesk.createIncidentWatch(100, watch, function (res) {
+    console.log( "Successfully created watch #" + res.watch.id )
+});
+```
+The INCREMENT is needed because `watched_by` is a mandatory POST parameter. If you need to create multiple external watchlists for a same incident, INCREMENT must be different for each of them. 
+
+If you want to notify the people in the watchlists (external and internal), you must update the incident with the POST parameter `notify_watchlisted` set to true after the creation of the said watchlists.
+
+
 View http://support.citrixonline.com/s/G2ASD/Help/APIDocs for API documentation.

--- a/src/ServiceDesk.coffee
+++ b/src/ServiceDesk.coffee
@@ -52,6 +52,11 @@ class ServiceDesk
     payload = change: payload
     this.XHR "PUT", "/changes/#{id}.json", null, null, callback
 
+  #  Watches API Calls
+  createIncidentWatch:(incident_id, payload, callback) ->
+    payload = watch: payload
+    this.XHR "POST", "/incidents/#{incident_id}/watches.json", null, payload, callback
+
   #  Release API Calls
   showReleases:(params, callback) ->
     this.XHR "GET", "/releases.json", params, null, callback


### PR DESCRIPTION
Hi,
I needed to be able to create watchlists for incidents in my project. I've implemented and documented this new feature. 

Can you review my work and make it available through npm?

Best regards,
Jonathan.